### PR TITLE
Style Uniformity Change

### DIFF
--- a/src/controller/BoardController.cpp
+++ b/src/controller/BoardController.cpp
@@ -7,7 +7,7 @@
  * @param model
  * @param display
  */
-BoardController::BoardController(BoardModel *model, Display *display) : DisplayController(model, display) {
+BoardController::BoardController(BoardModel* model, Display* display) : DisplayController(model, display) {
     this->levelManager = new LevelManager(model);
 }
 

--- a/src/controller/BoardController.hpp
+++ b/src/controller/BoardController.hpp
@@ -7,7 +7,7 @@
 
 class BoardController : public DisplayController {
 public:
-    BoardController(BoardModel *model, Display *display);
+    BoardController(BoardModel* model, Display* display);
 
 protected:
     LevelManager* getLevelManager() const;

--- a/src/controller/Display.cpp
+++ b/src/controller/Display.cpp
@@ -8,7 +8,7 @@
  * @param window
  * @param renderer
  */
-Display::Display(SDL_Window *window, SDL_Renderer *renderer) {
+Display::Display(SDL_Window* window, SDL_Renderer* renderer) {
     this->window = window;
     this->renderer = renderer;
 }
@@ -48,7 +48,7 @@ void Display::draw() const {
  * @param name
  * @param view
  */
-void Display::addView(std::string name, View *view) {
+void Display::addView(std::string name, View* view) {
     deleteViewIfExists(name);
     viewMap[name] = view;
     viewNameStack.push_back(name);
@@ -112,7 +112,7 @@ void Display::advanceAnimations() {
  * @param y y coordinate
  * @return View*
  */
-View *Display::getViewUnderCoordinate(uint32_t x, uint32_t y) const {
+View* Display::getViewUnderCoordinate(uint32_t x, uint32_t y) const {
     View* matchingView = nullptr;
 
     for (auto viewNameIterator = viewNameStack.rbegin(); viewNameIterator != viewNameStack.rend(); viewNameIterator++) {

--- a/src/controller/DisplayController.cpp
+++ b/src/controller/DisplayController.cpp
@@ -26,7 +26,7 @@ BaseModel* DisplayController::getModel() const {
  * Get the display where views are put onto the screen.
  * @return Display*
  */
-Display *DisplayController::getDisplay() const {
+Display* DisplayController::getDisplay() const {
     return display;
 }
 
@@ -107,7 +107,7 @@ void DisplayController::processInput() {
                    event.type == SDL_MOUSEMOTION) {
             auto x = (uint32_t) event.button.x;
             auto y = (uint32_t) event.button.y;
-            View *view = getDisplay()->getViewUnderCoordinate(x, y);
+            View* view = getDisplay()->getViewUnderCoordinate(x, y);
             if (view != nullptr) {
                 if (event.type == SDL_MOUSEBUTTONUP) {
                     view->onMouseUp(event);

--- a/src/controller/EditorController.cpp
+++ b/src/controller/EditorController.cpp
@@ -59,7 +59,7 @@ EditorController::EditorController(EditorBoardModel* model, Display* display, ui
  * Fetch the sub-classed model for this controller.
  * @return the model
  */
-EditorBoardModel *EditorController::getModel() const {
+EditorBoardModel* EditorController::getModel() const {
     return (EditorBoardModel*) DisplayController::getModel();
 }
 
@@ -180,7 +180,7 @@ View* EditorController::createSaveButton(View* board, uint8_t buttonSpacing) con
  * @param buttonSpacing horizontal pixel distance between neighboring buttons
  * @return
  */
-View *EditorController::createBackButton(View *board, int buttonSpacing) const {
+View* EditorController::createBackButton(View* board, int buttonSpacing) const {
     SDL_Rect rect = {0, 0, 50, 30};
     rect.x = board->getWidth() - 1 * rect.w - 1 * buttonSpacing;
     rect.y = board->getHeight() + buttonSpacing;
@@ -203,7 +203,7 @@ View *EditorController::createBackButton(View *board, int buttonSpacing) const {
  * @param buttonSpacing
  * @return
  */
-View *EditorController::createTileTypeButton(View* board, TileType tileType, uint8_t buttonSpacing) const {
+View* EditorController::createTileTypeButton(View* board, TileType tileType, uint8_t buttonSpacing) const {
     const uint16_t width  = 40;
     const uint16_t height = 27;
     const uint8_t initialOffset = 10;

--- a/src/controller/EditorController.hpp
+++ b/src/controller/EditorController.hpp
@@ -18,7 +18,7 @@ private:
     View* createRectangle() const;
     View* createBoard() const;
     View* createSaveButton(View* board, uint8_t buttonSpacing) const;
-    View* createBackButton(View *board, int buttonSpacing) const;
+    View* createBackButton(View* board, int buttonSpacing) const;
     View* createTileTypeButton(View* board, TileType tileType, uint8_t buttonSpacing) const;
 };
 

--- a/src/controller/GameController.cpp
+++ b/src/controller/GameController.cpp
@@ -219,7 +219,7 @@ void GameController::sizeWindowAndShow(SDL_Window* window) {
  * This model contains references to all models used by the entire game.
  * @return
  */
-GameModel *GameController::getModel() const {
+GameModel* GameController::getModel() const {
     return this->gameModel;
 }
 

--- a/src/controller/GameController.hpp
+++ b/src/controller/GameController.hpp
@@ -25,11 +25,11 @@ private:
     void buildDisplay();
     void initializeSdl();
     SDL_Window* createWindow();
-    void sizeWindowAndShow(SDL_Window *window);
-    SDL_Renderer* createRenderer(SDL_Window *window);
+    void sizeWindowAndShow(SDL_Window* window);
+    SDL_Renderer* createRenderer(SDL_Window* window);
 
     GameModel* gameModel;
-    Display *display;
+    Display* display;
     bool firstLoop;
 };
 

--- a/src/controller/GameOverController.cpp
+++ b/src/controller/GameOverController.cpp
@@ -6,7 +6,7 @@
  * @param model
  * @param display
  */
-GameOverController::GameOverController(GameOverModel *model, Display *display) : DisplayController(model, display) {
+GameOverController::GameOverController(GameOverModel* model, Display* display) : DisplayController(model, display) {
     auto mainMenu = createMainMenu();
     getDisplay()->addView("main_menu", mainMenu);
     getDisplay()->setFocus("main_menu");
@@ -45,7 +45,7 @@ bool GameOverController::isStillExecuting() const {
  * Create the main menu of the Game Over Screen.
  * @return View*
  */
-View *GameOverController::createMainMenu() {
+View* GameOverController::createMainMenu() {
     SDL_Rect rect = {0, 240, 300, 200};
     rect.x = (getDisplay()->getWidth() - rect.w) / 2;
     auto mainMenu = new MenuView(nullptr, rect);
@@ -86,7 +86,7 @@ View *GameOverController::createMainMenu() {
  * Create and return the Game Over text that appears on the the screen.
  * @return View*
  */
-View *GameOverController::createGameOverMenu() {
+View* GameOverController::createGameOverMenu() {
     SDL_Rect rect = {0, 30, 300, 200};
     rect.x = (getDisplay()->getWidth() - rect.w) / 2;
     auto gameOverLabel = new LabelView(nullptr, rect);

--- a/src/controller/GameOverController.hpp
+++ b/src/controller/GameOverController.hpp
@@ -6,7 +6,7 @@
 
 class GameOverController : public DisplayController {
 public:
-    GameOverController(GameOverModel *model, Display *display);
+    GameOverController(GameOverModel* model, Display* display);
 
 
 protected:
@@ -16,7 +16,7 @@ protected:
 
 private:
     View* createMainMenu();
-    View *createGameOverMenu();
+    View* createGameOverMenu();
 };
 
 #endif

--- a/src/controller/GameWinController.cpp
+++ b/src/controller/GameWinController.cpp
@@ -6,7 +6,7 @@
  * @param model
  * @param display
  */
-GameWinController::GameWinController(BaseModel *model, Display *display) : DisplayController(model, display) {
+GameWinController::GameWinController(BaseModel* model, Display* display) : DisplayController(model, display) {
     auto youWinLabel = createYouWinLabel();
     getDisplay()->addView("you_win", youWinLabel);
 
@@ -19,7 +19,7 @@ GameWinController::GameWinController(BaseModel *model, Display *display) : Displ
  * Get the model for this controller.
  * @return GameWinModel*
  */
-GameWinModel *GameWinController::getModel() const {
+GameWinModel* GameWinController::getModel() const {
     return dynamic_cast<GameWinModel*>(DisplayController::getModel());
 }
 
@@ -43,7 +43,7 @@ bool GameWinController::isStillExecuting() const {
  * Creates a menu which allows the user to return to title or quit the game.
  * @return View*
  */
-View *GameWinController::createMenu() const {
+View* GameWinController::createMenu() const {
     SDL_Rect rect = {0, 240, 200, 200};
     rect.x = (getDisplay()->getWidth() - rect.w) / 2;
     auto returnToTitle = new MenuView(nullptr, rect);
@@ -77,7 +77,7 @@ View *GameWinController::createMenu() const {
  * Creates a label that tells the player they won.
  * @return View*
  */
-View *GameWinController::createYouWinLabel() const {
+View* GameWinController::createYouWinLabel() const {
     SDL_Rect rect = {0, 30, 300, 200};
     rect.x = (getDisplay()->getWidth() - rect.w) / 2;
     auto youWinLabel = new LabelView(nullptr, rect);

--- a/src/controller/GameWinController.hpp
+++ b/src/controller/GameWinController.hpp
@@ -6,14 +6,14 @@
 
 class GameWinController : public DisplayController {
 public:
-    GameWinController(BaseModel *model, Display *display);
+    GameWinController(BaseModel* model, Display* display);
 
 protected:
     GameWinModel* getModel() const final;
     void updateModel(long frameDuration) override;
     bool isStillExecuting() const override;
-    View *createMenu() const;
-    View *createYouWinLabel() const;
+    View* createMenu() const;
+    View* createYouWinLabel() const;
 };
 
 #endif

--- a/src/controller/PlayController.cpp
+++ b/src/controller/PlayController.cpp
@@ -14,7 +14,7 @@
  * @param display
  * @param startingLevel
  */
-PlayController::PlayController(PlayBoardModel *model, Display* display, uint8_t startingLevel) : BoardController(model,
+PlayController::PlayController(PlayBoardModel* model, Display* display, uint8_t startingLevel) : BoardController(model,
         display) {
     // Initialize the model
     getModel()->setTimeClock(50000);
@@ -69,7 +69,7 @@ void PlayController::updateLevel(long elapsedDuration) const {
  * Fetch the sub-classed model for this controller.
  * @return the model
  */
-PlayBoardModel *PlayController::getModel() const {
+PlayBoardModel* PlayController::getModel() const {
     return (PlayBoardModel*) DisplayController::getModel();
 }
 

--- a/src/controller/TitleScreenController.cpp
+++ b/src/controller/TitleScreenController.cpp
@@ -9,7 +9,7 @@
  * @param model
  * @param display
  */
-TitleScreenController::TitleScreenController(TitleScreenModel* model, Display *display) : DisplayController(model,
+TitleScreenController::TitleScreenController(TitleScreenModel* model, Display* display) : DisplayController(model,
         display) {
     createKeyImage();
     createKeyRunnerText();
@@ -181,6 +181,6 @@ void TitleScreenController::createEditorLevelSelectorMenu() {
  * Fetch the sub-classed model for this controller.
  * @return the model
  */
-TitleScreenModel *TitleScreenController::getModel() const {
+TitleScreenModel* TitleScreenController::getModel() const {
     return dynamic_cast<TitleScreenModel*>(DisplayController::getModel());
 }

--- a/src/model/GameModel.cpp
+++ b/src/model/GameModel.cpp
@@ -32,7 +32,7 @@ GameModel::~GameModel() {
  * Fetch the Title Screen's model.
  * @return TitleScreenModel*
  */
-TitleScreenModel *GameModel::getTitleScreenModel() const {
+TitleScreenModel* GameModel::getTitleScreenModel() const {
     return this->titleScreenModel;
 }
 
@@ -40,7 +40,7 @@ TitleScreenModel *GameModel::getTitleScreenModel() const {
  * Fetch the Editor's model.
  * @return EditorBoardModel*
  */
-EditorBoardModel *GameModel::getEditorBoardModel() const {
+EditorBoardModel* GameModel::getEditorBoardModel() const {
     return this->editorBoardModel;
 }
 
@@ -48,7 +48,7 @@ EditorBoardModel *GameModel::getEditorBoardModel() const {
  * Fetch the Play model.
  * @return PlayBoardModel*
  */
-PlayBoardModel *GameModel::getPlayBoardModel() const {
+PlayBoardModel* GameModel::getPlayBoardModel() const {
     return this->playBoardModel;
 }
 
@@ -56,7 +56,7 @@ PlayBoardModel *GameModel::getPlayBoardModel() const {
  * Fetch the option model
  * @return OptionModel*
  */
-OptionModel *GameModel::getOptionModel() const {
+OptionModel* GameModel::getOptionModel() const {
     return this->optionModel;
 }
 

--- a/src/model/GameModel.hpp
+++ b/src/model/GameModel.hpp
@@ -20,8 +20,8 @@ public:
     EditorBoardModel* getEditorBoardModel() const;
     PlayBoardModel* getPlayBoardModel() const;
     OptionModel* getOptionModel() const;
-    GameOverModel *getGameOverModel() const;
-    GameWinModel *getGameWinModel() const;
+    GameOverModel* getGameOverModel() const;
+    GameWinModel* getGameWinModel() const;
 
 private:
     TitleScreenModel* titleScreenModel;

--- a/src/model/LevelManager.cpp
+++ b/src/model/LevelManager.cpp
@@ -69,7 +69,7 @@ bool LevelManager::levelExists(uint8_t levelNumber) const {
  */
 void LevelManager::write() const {
     std::string levelFile = getPath(board->getLevelNum(), true);
-    FILE *fp = fopen(levelFile.c_str(), "wb");
+    FILE* fp = fopen(levelFile.c_str(), "wb");
     writeSize(fp);
     writeDefaultTileType(fp);
     writeInitialPlayerCoordinate(fp);
@@ -104,7 +104,7 @@ void LevelManager::read() {
  * Read the level's items from the persistent storage.
  * @param fp
  */
-void LevelManager::readItems(FILE *fp) {
+void LevelManager::readItems(FILE* fp) {
     // Read Count of Items.
     // Hardcoded to 1 since there can only be a key in the puzzle for now.
     uint16_t itemCount;
@@ -122,7 +122,7 @@ void LevelManager::readItems(FILE *fp) {
  * Read the level's deviations to the default tile type from the persistent storage.
  * @param fp
  */
-void LevelManager::readDeviations(FILE *fp) {
+void LevelManager::readDeviations(FILE* fp) {
     // Read Tile Deviation Count
     uint16_t deviationCount;
     fread(&deviationCount, sizeof(uint16_t), 1, fp);
@@ -148,7 +148,7 @@ void LevelManager::readDeviations(FILE *fp) {
  * Read the initial tile coordinate of the player.
  * @param fp
  */
-void LevelManager::readInitialPlayerCoordinate(FILE *fp) {
+void LevelManager::readInitialPlayerCoordinate(FILE* fp) {
     fread(&playerCoordinate.first, sizeof(uint16_t), 1, fp);
     fread(&playerCoordinate.second, sizeof(uint16_t), 1, fp);
 }
@@ -157,7 +157,7 @@ void LevelManager::readInitialPlayerCoordinate(FILE *fp) {
  * Read the default tile type.
  * @param fp
  */
-void LevelManager::readDefaultTileType(FILE *fp) {
+void LevelManager::readDefaultTileType(FILE* fp) {
     // Read Default Tile Type
     uint8_t defaultTileTypeInteger;
     fread(&defaultTileTypeInteger, sizeof(uint8_t), 1, fp);
@@ -171,7 +171,7 @@ void LevelManager::readDefaultTileType(FILE *fp) {
  * this can now be changed.
  * @param fp
  */
-void LevelManager::readSize(FILE *fp) {
+void LevelManager::readSize(FILE* fp) {
     // Read Width and Height and discard the result.
     fread(&width, sizeof(uint16_t), 1, fp);
     fread(&height, sizeof(uint16_t), 1, fp);

--- a/src/model/LevelManager.hpp
+++ b/src/model/LevelManager.hpp
@@ -24,11 +24,11 @@ private:
     void resetLevelManager();
     void populateBoard();
 
-    void readSize(FILE *fp);
-    void readDefaultTileType(FILE *fp);
-    void readInitialPlayerCoordinate(FILE *fp);
-    void readDeviations(FILE *fp);
-    void readItems(FILE *fp);
+    void readSize(FILE* fp);
+    void readDefaultTileType(FILE* fp);
+    void readInitialPlayerCoordinate(FILE* fp);
+    void readDeviations(FILE* fp);
+    void readItems(FILE* fp);
 
     void writeSize(FILE* fp) const;
     void writeDefaultTileType(FILE* fp) const;

--- a/src/uitk/Animation.cpp
+++ b/src/uitk/Animation.cpp
@@ -65,7 +65,7 @@ bool Animation::advance() {
  * Draw the current frame of the animation onto the screen.
  * @param SDL_Renderer*
  */
-void Animation::draw(SDL_Renderer *renderer) {
+void Animation::draw(SDL_Renderer* renderer) {
     // Look into the frame list to determine the logical coordinates of the
     // frame in the sprite sheet.
     auto frameXc = static_cast<uint16_t>(this->currentStill * 2 + 0);

--- a/src/uitk/Animation.hpp
+++ b/src/uitk/Animation.hpp
@@ -9,7 +9,7 @@ class Animation {
 public:
     Animation(SpriteSheet* spriteSheet, std::vector<uint16_t> frameList, uint16_t stillsPerSecond);
     bool advance();
-    void draw(SDL_Renderer *renderer);
+    void draw(SDL_Renderer* renderer);
     void move(uint16_t x, uint16_t y);
     bool isAnimating() const;
     void play();

--- a/src/uitk/BaseView.hpp
+++ b/src/uitk/BaseView.hpp
@@ -38,7 +38,7 @@ protected:
     void addAnimation(Animation*);
 
 private:
-    Model *model;
+    Model* model;
     SDL_Rect rect;
     bool visible;
     std::vector<Animation *> animations;

--- a/src/uitk/ButtonView.cpp
+++ b/src/uitk/ButtonView.cpp
@@ -15,7 +15,7 @@ ButtonView::ButtonView(Model* model, const SDL_Rect &rect) : LabelView(model, re
  * Eventually, this could support on click and hover. Right now, it does nothing more than LabelView::draw().
  * @param renderer
  */
-void ButtonView::draw(SDL_Renderer *renderer) {
+void ButtonView::draw(SDL_Renderer* renderer) {
     LabelView::draw(renderer);
 }
 

--- a/src/uitk/ImageView.cpp
+++ b/src/uitk/ImageView.cpp
@@ -11,7 +11,7 @@ extern AnimationFactory* animationFactory;
  * @param rect
  * @param animationType
  */
-ImageView::ImageView(Model *model, const SDL_Rect &rect, AnimationType animationType) : RectangleView(model, rect) {
+ImageView::ImageView(Model* model, const SDL_Rect &rect, AnimationType animationType) : RectangleView(model, rect) {
     animation = animationFactory->build(animationType);
     setHorizontalAlignment(HorizontalAlignment::LEFT);
     setVerticalAlignment(VerticalAlignment::BOTTOM);

--- a/src/uitk/ImageView.hpp
+++ b/src/uitk/ImageView.hpp
@@ -8,7 +8,7 @@
 
 class ImageView : public RectangleView {
 public:
-    ImageView(Model *model, const SDL_Rect &rect, AnimationType animationType);
+    ImageView(Model* model, const SDL_Rect &rect, AnimationType animationType);
     ~ImageView() override;
     void draw(SDL_Renderer* renderer) override;
     void setHorizontalAlignment(HorizontalAlignment alignment);

--- a/src/uitk/LabelView.cpp
+++ b/src/uitk/LabelView.cpp
@@ -214,7 +214,7 @@ void LabelView::setFontPath(std::string fontPath) {
  * Given the renderer, draw a label onto it.
  * @param renderer
  */
-void LabelView::draw(SDL_Renderer *renderer) {
+void LabelView::draw(SDL_Renderer* renderer) {
     RectangleView::draw(renderer);
 
     // Fetch the text. Subclasses are allowed to have set textDirty by indirectly calling setText()

--- a/src/uitk/LabelView.hpp
+++ b/src/uitk/LabelView.hpp
@@ -30,7 +30,7 @@ public:
 
 private:
     TTF_Font* getFont(uint8_t size) const;
-    SDL_Texture* makeTextTexture(SDL_Renderer *renderer) const;
+    SDL_Texture* makeTextTexture(SDL_Renderer* renderer) const;
     uint32_t chooseFontSizeToFit() const;
 
     std::string text;

--- a/src/uitk/MenuView.cpp
+++ b/src/uitk/MenuView.cpp
@@ -6,7 +6,7 @@
  * @param model
  * @param rect
  */
-MenuView::MenuView(Model *model, const SDL_Rect &rect) : RectangleView(model, rect) {
+MenuView::MenuView(Model* model, const SDL_Rect &rect) : RectangleView(model, rect) {
     setCursorIndex(0);
     setVisibleOptionCount(0);
     setWindowTopIndex(0);
@@ -36,7 +36,7 @@ void MenuView::addOption(std::string optionText, const std::function<void(SDL_Ev
  * Draw each of the visible buttons on the menu.
  * @param renderer
  */
-void MenuView::draw(SDL_Renderer *renderer) {
+void MenuView::draw(SDL_Renderer* renderer) {
     for (ButtonView* button : buttons) {
         if (button->isVisible()) {
             button->draw(renderer);

--- a/src/uitk/MenuView.hpp
+++ b/src/uitk/MenuView.hpp
@@ -7,7 +7,7 @@
 
 class MenuView : public RectangleView {
 public:
-    MenuView(Model *model, const SDL_Rect &rect);
+    MenuView(Model* model, const SDL_Rect &rect);
     void draw(SDL_Renderer* renderer) override;
     void onMouseHover(SDL_Event event) override;
     void onMouseUp(SDL_Event event) override;

--- a/src/uitk/RectangleView.cpp
+++ b/src/uitk/RectangleView.cpp
@@ -13,7 +13,7 @@ RectangleView::RectangleView(Model* model, const SDL_Rect &rect) : BaseView(mode
  * Draws a rectangle to the screen using the color field.
  * @param renderer
  */
-void RectangleView::draw(SDL_Renderer *renderer) {
+void RectangleView::draw(SDL_Renderer* renderer) {
     auto red = static_cast<uint8_t>((color & 0xFF0000) >> 16);
     auto green = static_cast<uint8_t>((color & 0x00FF00) >> 8);
     auto blue = static_cast<uint8_t>((color & 0x0000FF) >> 0);

--- a/src/uitk/SpriteSheet.cpp
+++ b/src/uitk/SpriteSheet.cpp
@@ -49,7 +49,7 @@ uint16_t SpriteSheet::getHeight() const {
  * @param stillY Y coordinate of still to draw
  * @param where draw still to this destination rectangle
  */
-void SpriteSheet::drawStill(SDL_Renderer *renderer, uint16_t stillX, uint16_t stillY, SDL_Rect &where) {
+void SpriteSheet::drawStill(SDL_Renderer* renderer, uint16_t stillX, uint16_t stillY, SDL_Rect &where) {
     // Source Rect
     SDL_Rect source = {stillX * width, stillY * width, width, height};
 

--- a/src/uitk/SpriteSheet.hpp
+++ b/src/uitk/SpriteSheet.hpp
@@ -8,7 +8,7 @@ class SpriteSheet {
 public:
     SpriteSheet(SDL_Renderer* renderer, std::string filename, uint16_t width, uint16_t height);
     ~SpriteSheet();
-    void drawStill(SDL_Renderer *renderer, uint16_t stillX, uint16_t stillY, SDL_Rect &where);
+    void drawStill(SDL_Renderer* renderer, uint16_t stillX, uint16_t stillY, SDL_Rect &where);
 
     uint16_t getWidth() const;
     uint16_t getHeight() const;

--- a/src/view/EditorBoardView.cpp
+++ b/src/view/EditorBoardView.cpp
@@ -6,7 +6,7 @@
  * @param model
  * @param rect
  */
-EditorBoardView::EditorBoardView(EditorBoardModel *model, const SDL_Rect &rect) : BoardView(model, rect) {}
+EditorBoardView::EditorBoardView(EditorBoardModel* model, const SDL_Rect &rect) : BoardView(model, rect) {}
 
 /**
  * Draw the board.
@@ -14,7 +14,7 @@ EditorBoardView::EditorBoardView(EditorBoardModel *model, const SDL_Rect &rect) 
  * Also draw the tile position that the mouse is currently hovering over.
  * @param renderer
  */
-void EditorBoardView::draw(SDL_Renderer *renderer) {
+void EditorBoardView::draw(SDL_Renderer* renderer) {
     // Draw the board first
     BoardView::draw(renderer);
 

--- a/src/view/EditorBoardView.hpp
+++ b/src/view/EditorBoardView.hpp
@@ -6,12 +6,12 @@
 
 class EditorBoardView : public BoardView {
 public:
-    EditorBoardView(EditorBoardModel *model, const SDL_Rect &rect);
+    EditorBoardView(EditorBoardModel* model, const SDL_Rect &rect);
     void draw(SDL_Renderer* renderer) override;
     EditorBoardModel* getModel() const override;
 
 private:
-    void drawCursorTile(SDL_Renderer *renderer, bool justHighlight);
+    void drawCursorTile(SDL_Renderer* renderer, bool justHighlight);
 };
 
 #endif

--- a/src/view/LevelNumberView.cpp
+++ b/src/view/LevelNumberView.cpp
@@ -6,7 +6,7 @@
  * @param model
  * @param rect
  */
-LevelNumberView::LevelNumberView(BoardModel *model, const SDL_Rect &rect) : LabelView(model, rect) {}
+LevelNumberView::LevelNumberView(BoardModel* model, const SDL_Rect &rect) : LabelView(model, rect) {}
 
 /**
  * Gets the text of this label.

--- a/src/view/TimerView.cpp
+++ b/src/view/TimerView.cpp
@@ -27,6 +27,6 @@ std::string TimerView::getText() {
  * Get the model to which this label is bound.
  * @return PlayModel*
  */
-PlayBoardModel *TimerView::getModel() const {
+PlayBoardModel* TimerView::getModel() const {
     return (PlayBoardModel*) LabelView::getModel();
 }


### PR DESCRIPTION
This change causes the asterisk to be associated with the type, and not
the name of the variable. Previously, it was 50% uniform across the code
base. Now it is so everywhere.