### PR TITLE
Small efficiency change

### DIFF
--- a/src/view/AnimationFactory.cpp
+++ b/src/view/AnimationFactory.cpp
@@ -39,7 +39,7 @@ Animation* AnimationFactory::build(AnimationType animationType) {
 
         return new Animation(getSpriteSheet(animationType), frameList, stillsPerSecond);
 
-    } catch (std::invalid_argument exception) {
+    } catch (std::invalid_argument& exception) {
         std::stringstream errorMessage;
         errorMessage << "Couldn't build Animation (type = " << animationType << ") reason: " << exception.what();
         throw std::logic_error(errorMessage.str());


### PR DESCRIPTION
This is a minor change. Exceptions should be caught by reference, and
not by value. This fixes the one place in the code where this is the
case.